### PR TITLE
Add reviews CRUD and login via username

### DIFF
--- a/cmd/initializer.go
+++ b/cmd/initializer.go
@@ -21,27 +21,34 @@ import (
 )
 
 type application struct {
-	errorLog    *log.Logger
-	infoLog     *log.Logger
-	userHandler *handlers.UserHandler
-	userRepo    *repositories.UserRepository
+	errorLog      *log.Logger
+	infoLog       *log.Logger
+	userHandler   *handlers.UserHandler
+	userRepo      *repositories.UserRepository
+	reviewHandler *handlers.ReviewHandler
+	reviewRepo    *repositories.ReviewRepository
 }
 
 func initializeApp(db *sql.DB, errorLog, infoLog *log.Logger) *application {
 	// Repositories
 	userRepo := repositories.UserRepository{DB: db}
+	reviewRepo := repositories.ReviewRepository{DB: db}
 
 	// Services
 	userService := &services.UserService{UserRepo: &userRepo}
+	reviewService := &services.ReviewService{Repo: &reviewRepo}
 
 	// Handlers
 	userHandler := &handlers.UserHandler{Service: userService}
+	reviewHandler := &handlers.ReviewHandler{Service: reviewService}
 
 	return &application{
-		errorLog:    errorLog,
-		infoLog:     infoLog,
-		userHandler: userHandler,
-		userRepo:    &userRepo,
+		errorLog:      errorLog,
+		infoLog:       infoLog,
+		userHandler:   userHandler,
+		userRepo:      &userRepo,
+		reviewHandler: reviewHandler,
+		reviewRepo:    &reviewRepo,
 	}
 }
 

--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -28,6 +28,13 @@ func (app *application) routes() http.Handler {
 	mux.Post("/user/upgrade", clientAuthMiddleware.ThenFunc(app.userHandler.UpgradeToTrainer))
 	mux.Put("/user/profile", authMiddleware.ThenFunc(app.userHandler.UpdateProfile))
 
+	// Reviews
+	mux.Post("/reviews", authMiddleware.ThenFunc(app.reviewHandler.Create))
+	mux.Get("/reviews", authMiddleware.ThenFunc(app.reviewHandler.GetAll))
+	mux.Get("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.GetByID))
+	mux.Put("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Update))
+	mux.Del("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Delete))
+
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 
 	return standardMiddleware.Then(mux)

--- a/internal/handlers/review_handler.go
+++ b/internal/handlers/review_handler.go
@@ -1,0 +1,72 @@
+package handlers
+
+import (
+	"encoding/json"
+	"net/http"
+	"strconv"
+
+	"reviews/internal/models"
+	"reviews/internal/services"
+)
+
+type ReviewHandler struct {
+	Service *services.ReviewService
+}
+
+func (h *ReviewHandler) Create(w http.ResponseWriter, r *http.Request) {
+	var rev models.Reviews
+	if err := json.NewDecoder(r.Body).Decode(&rev); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	created, err := h.Service.Create(r.Context(), rev)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(created)
+}
+
+func (h *ReviewHandler) GetAll(w http.ResponseWriter, r *http.Request) {
+	reviews, err := h.Service.GetAll(r.Context())
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(reviews)
+}
+
+func (h *ReviewHandler) GetByID(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	rev, err := h.Service.GetByID(r.Context(), id)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(rev)
+}
+
+func (h *ReviewHandler) Update(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	var rev models.Reviews
+	if err := json.NewDecoder(r.Body).Decode(&rev); err != nil {
+		http.Error(w, "invalid body", http.StatusBadRequest)
+		return
+	}
+	rev.ID = id
+	updated, err := h.Service.Update(r.Context(), rev)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	json.NewEncoder(w).Encode(updated)
+}
+
+func (h *ReviewHandler) Delete(w http.ResponseWriter, r *http.Request) {
+	id, _ := strconv.Atoi(r.URL.Query().Get(":id"))
+	if err := h.Service.Delete(r.Context(), id); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -73,7 +73,7 @@ func (h *UserHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp, err := h.Service.SignIn(r.Context(), req.Email, req.Password)
+	resp, err := h.Service.SignIn(r.Context(), req.Login, req.Password)
 	if err != nil {
 		log.Printf("error: %v", err)
 		http.Error(w, "Invalid credentials", http.StatusUnauthorized)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -34,7 +34,7 @@ type Session struct {
 }
 
 type SignInRequest struct {
-	Email    string `json:"email"`
+	Login    string `json:"login"`
 	Password string `json:"password"`
 }
 

--- a/internal/repositories/review_repository.go
+++ b/internal/repositories/review_repository.go
@@ -1,0 +1,76 @@
+package repositories
+
+import (
+	"context"
+	"database/sql"
+	"reviews/internal/models"
+	"time"
+)
+
+type ReviewRepository struct {
+	DB *sql.DB
+}
+
+func (r *ReviewRepository) CreateReview(ctx context.Context, rev models.Reviews) (models.Reviews, error) {
+	rev.CreatedAt = time.Now()
+	rev.UpdatedAt = &rev.CreatedAt
+	query := `INSERT INTO reviews (name, photo, description, rating, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+	res, err := r.DB.ExecContext(ctx, query, rev.Name, rev.Photo, rev.Description, rev.Rating, rev.CreatedAt, rev.UpdatedAt)
+	if err != nil {
+		return models.Reviews{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return models.Reviews{}, err
+	}
+	rev.ID = int(id)
+	return rev, nil
+}
+
+func (r *ReviewRepository) GetReviews(ctx context.Context) ([]models.Reviews, error) {
+	rows, err := r.DB.QueryContext(ctx, `SELECT id, name, photo, description, rating, created_at, updated_at FROM reviews`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var res []models.Reviews
+	for rows.Next() {
+		var rev models.Reviews
+		err := rows.Scan(&rev.ID, &rev.Name, &rev.Photo, &rev.Description, &rev.Rating, &rev.CreatedAt, &rev.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		res = append(res, rev)
+	}
+	return res, nil
+}
+
+func (r *ReviewRepository) GetReviewByID(ctx context.Context, id int) (models.Reviews, error) {
+	var rev models.Reviews
+	err := r.DB.QueryRowContext(ctx, `SELECT id, name, photo, description, rating, created_at, updated_at FROM reviews WHERE id = ?`, id).Scan(
+		&rev.ID, &rev.Name, &rev.Photo, &rev.Description, &rev.Rating, &rev.CreatedAt, &rev.UpdatedAt,
+	)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return models.Reviews{}, sql.ErrNoRows
+		}
+		return models.Reviews{}, err
+	}
+	return rev, nil
+}
+
+func (r *ReviewRepository) UpdateReview(ctx context.Context, rev models.Reviews) (models.Reviews, error) {
+	now := time.Now()
+	rev.UpdatedAt = &now
+	query := `UPDATE reviews SET name = ?, photo = ?, description = ?, rating = ?, updated_at = ? WHERE id = ?`
+	_, err := r.DB.ExecContext(ctx, query, rev.Name, rev.Photo, rev.Description, rev.Rating, rev.UpdatedAt, rev.ID)
+	if err != nil {
+		return models.Reviews{}, err
+	}
+	return rev, nil
+}
+
+func (r *ReviewRepository) DeleteReview(ctx context.Context, id int) error {
+	_, err := r.DB.ExecContext(ctx, `DELETE FROM reviews WHERE id = ?`, id)
+	return err
+}

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -89,6 +89,27 @@ func (r *UserRepository) GetUserByEmail(ctx context.Context, email string) (mode
 	return user, nil
 }
 
+func (r *UserRepository) GetUserByLogin(ctx context.Context, login string) (models.User, error) {
+	var user models.User
+	query := `
+        SELECT id, name, phone, email, password, role, created_at, updated_at
+        FROM users
+        WHERE name = ?
+    `
+	err := r.DB.QueryRowContext(ctx, query, login).Scan(
+		&user.ID, &user.Name, &user.Phone, &user.Email, &user.Password,
+		&user.Role,
+		&user.CreatedAt, &user.UpdatedAt,
+	)
+	if err == sql.ErrNoRows {
+		return models.User{}, ErrUserNotFound
+	}
+	if err != nil {
+		return models.User{}, err
+	}
+	return user, nil
+}
+
 // GetUserByID retrieves a user by id.
 func (r *UserRepository) GetUserByID(ctx context.Context, id int) (models.User, error) {
 	var user models.User

--- a/internal/services/review_service.go
+++ b/internal/services/review_service.go
@@ -1,0 +1,31 @@
+package services
+
+import (
+	"context"
+	"reviews/internal/models"
+	"reviews/internal/repositories"
+)
+
+type ReviewService struct {
+	Repo *repositories.ReviewRepository
+}
+
+func (s *ReviewService) Create(ctx context.Context, rev models.Reviews) (models.Reviews, error) {
+	return s.Repo.CreateReview(ctx, rev)
+}
+
+func (s *ReviewService) GetAll(ctx context.Context) ([]models.Reviews, error) {
+	return s.Repo.GetReviews(ctx)
+}
+
+func (s *ReviewService) GetByID(ctx context.Context, id int) (models.Reviews, error) {
+	return s.Repo.GetReviewByID(ctx, id)
+}
+
+func (s *ReviewService) Update(ctx context.Context, rev models.Reviews) (models.Reviews, error) {
+	return s.Repo.UpdateReview(ctx, rev)
+}
+
+func (s *ReviewService) Delete(ctx context.Context, id int) error {
+	return s.Repo.DeleteReview(ctx, id)
+}

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -35,16 +35,16 @@ type UserService struct {
 	TokenManager *utils.Manager
 }
 
-func (s *UserService) SignIn(ctx context.Context, email, password string) (models.Tokens, error) {
-	user, err := s.UserRepo.GetUserByEmail(ctx, email)
+func (s *UserService) SignIn(ctx context.Context, login, password string) (models.Tokens, error) {
+	user, err := s.UserRepo.GetUserByLogin(ctx, login)
 	if err != nil {
-		log.Printf("User not found: %s", email)
+		log.Printf("User not found: %s", login)
 		return models.Tokens{}, errors.New("user not found")
 	}
 
 	// Compare the provided password with the hashed password
 	if err := bcrypt.CompareHashAndPassword([]byte(user.Password), []byte(password)); err != nil {
-		log.Printf("Invalid password for user: %s", email)
+		log.Printf("Invalid password for user: %s", login)
 		return models.Tokens{}, errors.New("invalid password")
 	}
 


### PR DESCRIPTION
## Summary
- support login using `login` field instead of email
- implement `Review` repository, service and HTTP handlers
- add initialization of review layer and configure routes for CRUD operations

## Testing
- `go build ./...` *(fails: modules cannot be downloaded)*

------
https://chatgpt.com/codex/tasks/task_e_686fb32724148324809746d22292ee8f