### PR TITLE
Implement sign up flow

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -19,6 +19,7 @@ func (app *application) routes() http.Handler {
 	mux := pat.New()
 
 	// Users
+	mux.Post("/user/sign_up", standardMiddleware.ThenFunc(app.userHandler.SignUp))
 	mux.Post("/user/sign_in", standardMiddleware.ThenFunc(app.userHandler.SignIn))
 
 	// Reviews

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -13,6 +13,24 @@ type UserHandler struct {
 	Service *services.UserService
 }
 
+func (h *UserHandler) SignUp(w http.ResponseWriter, r *http.Request) {
+	var req models.SignUpRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	tokens, err := h.Service.SignUp(r.Context(), req.Login, req.Password, req.Role)
+	if err != nil {
+		log.Printf("sign up error: %v", err)
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tokens)
+}
+
 func (h *UserHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 	var req models.SignInRequest
 	err := json.NewDecoder(r.Body).Decode(&req)

--- a/internal/models/user.go
+++ b/internal/models/user.go
@@ -35,3 +35,9 @@ type SignInRequest struct {
 	Login    string `json:"login"`
 	Password string `json:"password"`
 }
+
+type SignUpRequest struct {
+	Login    string `json:"login"`
+	Password string `json:"password"`
+	Role     string `json:"role,omitempty"`
+}

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	_ "fmt"
 	"reviews/internal/models"
-	_ "strings"
-	_ "time"
+	"time"
 )
 
 var (
@@ -81,4 +79,23 @@ func (r *UserRepository) GetUserByLogin(ctx context.Context, login string) (mode
 		return models.User{}, err
 	}
 	return user, nil
+}
+
+func (r *UserRepository) CreateUser(ctx context.Context, user models.User) (int, error) {
+	query := `
+                INSERT INTO users (name, password, role, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?)
+        `
+
+	res, err := r.DB.ExecContext(ctx, query, user.Name, user.Password, user.Role, time.Now(), time.Now())
+	if err != nil {
+		return 0, err
+	}
+
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+
+	return int(id), nil
 }


### PR DESCRIPTION
## Summary
- add user registration request model
- implement service method for user signup
- create repository method to insert a new user
- expose signup HTTP handler and route

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6870252ae22c8324a947e28d4f916aef