### PR TITLE
Add review image handler

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -28,6 +28,9 @@ func (app *application) routes() http.Handler {
 	mux.Put("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Update))
 	mux.Del("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Delete))
 
+	// Review images
+	mux.Get("/images/reviews/:filename", http.HandlerFunc(app.reviewHandler.ServeReviewImage))
+
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 
 	return standardMiddleware.Then(mux)


### PR DESCRIPTION
## Summary
- save review photos under `/images/reviews/<file>`
- implement `ServeReviewImage` handler
- expose new `GET /images/reviews/:filename` route

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6870252ae22c8324a947e28d4f916aef