### PR TITLE
Add review image handler

### DIFF
--- a/cmd/routes.go
+++ b/cmd/routes.go
@@ -20,6 +20,7 @@ func (app *application) routes() http.Handler {
 
 	// Users
 	mux.Post("/user/sign_in", standardMiddleware.ThenFunc(app.userHandler.SignIn))
+	mux.Post("/user/sign_up", standardMiddleware.ThenFunc(app.userHandler.SignUp))
 
 	// Reviews
 	mux.Post("/reviews", authMiddleware.ThenFunc(app.reviewHandler.Create))
@@ -27,6 +28,9 @@ func (app *application) routes() http.Handler {
 	mux.Get("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.GetByID))
 	mux.Put("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Update))
 	mux.Del("/reviews/:id", authMiddleware.ThenFunc(app.reviewHandler.Delete))
+
+	// Review images
+	mux.Get("/images/reviews/:filename", http.HandlerFunc(app.reviewHandler.ServeReviewImage))
 
 	// mux.Get("/swagger/", httpSwagger.WrapHandler)
 

--- a/internal/handlers/user_handler.go
+++ b/internal/handlers/user_handler.go
@@ -13,6 +13,25 @@ type UserHandler struct {
 	Service *services.UserService
 }
 
+// SignUp registers a new user and returns auth tokens.
+func (h *UserHandler) SignUp(w http.ResponseWriter, r *http.Request) {
+	var user models.User
+	if err := json.NewDecoder(r.Body).Decode(&user); err != nil {
+		http.Error(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	tokens, err := h.Service.SignUp(r.Context(), user)
+	if err != nil {
+		log.Printf("sign up error: %v", err)
+		http.Error(w, "failed to sign up", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(tokens)
+}
+
 func (h *UserHandler) SignIn(w http.ResponseWriter, r *http.Request) {
 	var req models.SignInRequest
 	err := json.NewDecoder(r.Body).Decode(&req)

--- a/internal/repositories/user_repository.go
+++ b/internal/repositories/user_repository.go
@@ -7,7 +7,7 @@ import (
 	_ "fmt"
 	"reviews/internal/models"
 	_ "strings"
-	_ "time"
+	"time"
 )
 
 var (
@@ -80,5 +80,25 @@ func (r *UserRepository) GetUserByLogin(ctx context.Context, login string) (mode
 	if err != nil {
 		return models.User{}, err
 	}
+	return user, nil
+}
+
+// CreateUser inserts a new user record and returns the created user with ID set.
+func (r *UserRepository) CreateUser(ctx context.Context, user models.User) (models.User, error) {
+	query := `
+        INSERT INTO users (name, password, role, created_at, updated_at)
+        VALUES (?, ?, ?, ?, ?)
+    `
+	user.CreatedAt = time.Now()
+	user.UpdatedAt = &user.CreatedAt
+	res, err := r.DB.ExecContext(ctx, query, user.Name, user.Password, user.Role, user.CreatedAt, user.UpdatedAt)
+	if err != nil {
+		return models.User{}, err
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return models.User{}, err
+	}
+	user.ID = int(id)
 	return user, nil
 }

--- a/internal/services/user_service.go
+++ b/internal/services/user_service.go
@@ -25,6 +25,37 @@ type UserService struct {
 	TokenManager *utils.Manager
 }
 
+// SignUp creates a new user and returns auth tokens for the newly created account.
+func (s *UserService) SignUp(ctx context.Context, user models.User) (models.Tokens, error) {
+	hashed, err := bcrypt.GenerateFromPassword([]byte(user.Password), bcrypt.DefaultCost)
+	if err != nil {
+		return models.Tokens{}, err
+	}
+	user.Password = string(hashed)
+	user.Role = "user"
+
+	created, err := s.UserRepo.CreateUser(ctx, user)
+	if err != nil {
+		return models.Tokens{}, err
+	}
+
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, &tokenClaims{
+		StandardClaims: jwt.StandardClaims{
+			ExpiresAt: time.Now().Add(tokenTTL).Unix(),
+			IssuedAt:  time.Now().Unix(),
+		},
+		UserID: created.ID,
+		Role:   created.Role,
+	})
+
+	accessToken, err := token.SignedString([]byte(signingKey))
+	if err != nil {
+		return models.Tokens{}, err
+	}
+
+	return s.CreateSession(ctx, created, accessToken)
+}
+
 func (s *UserService) SignIn(ctx context.Context, login, password string) (models.Tokens, error) {
 	user, err := s.UserRepo.GetUserByLogin(ctx, login)
 	if err != nil {


### PR DESCRIPTION
## Summary
- save review photos under `/images/reviews/<file>`
- implement `ServeReviewImage` handler
- expose new `GET /images/reviews/:filename` route
- add user sign up endpoint
- support multipart data in review updates

## Testing
- `go vet ./...` *(fails: Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6870252ae22c8324a947e28d4f916aef